### PR TITLE
Adjusted time for refresh to 30 minutes left vs 59

### DIFF
--- a/grading-assigner.py
+++ b/grading-assigner.py
@@ -131,7 +131,7 @@ def request_reviews(token):
             utcnow = datetime.utcnow()
             utcnow = utcnow.replace(tzinfo=pytz.utc)
 
-            if closing_at < utcnow + timedelta(minutes=59):
+            if closing_at < utcnow + timedelta(minutes=30):
                 # Refreshing a request is more costly than just loading
                 # and only needs to be done to ensure the request doesn't
                 # expire (1 hour)


### PR DESCRIPTION
Currently the script refreshes a request, waits 120 seconds, and then checks if the request has less than 59 minutes until it expires.  Since requests expire after 60 minutes and the loop is 2 minutes in wait the 59 minute refresh check is always true.  So every 2 minutes it refreshes.  Since a refresh is not needed except to prevent expiring requests I changed this to a more reasonable 30 minutes.  That way it only refreshes twice an hour, which is still pretty aggressive but not spammy.

fixes issue https://github.com/udacity/grading-assigner/issues/8#issue-183184765