### PR TITLE
Readme and reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Usage
 Requires the `requests` module, which you can either install globally or in a virtualenv.
 
+Install: pip install -r requirements.txt (expects Python to be installed along with pip)
+
 ```
 usage: grading-assigner.py [-h] [--auth-token TOKEN]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests==2.9.1
+pytz==2016.7
+python-dateutil==2.5.3


### PR DESCRIPTION
Added missing required modules to the requirements.txt file and the readme:
`pytz==2016.7`
`python-dateutil==2.5.3`

Also added simple install instructions to install modules form requirements.txt using pip

fixes this issue https://github.com/udacity/grading-assigner/issues/4#issue-182885020