### PR TITLE
Allow users to create a list with ids to query specific projects.

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,4 @@
+
+# User token:
+user_token = '' # paste user token
+ids_queued = [] # include projects ids to query

--- a/grading_assigment.py
+++ b/grading_assigment.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import signal
+import sys
+import argparse
+import logging
+import os
+import requests
+import time
+import pytz
+from dateutil import parser
+from datetime import datetime, timedelta
+import config
+
+utc = pytz.UTC
+
+# Script config
+BASE_URL = 'https://review-api.udacity.com/api/v1'
+CERTS_URL = '{}/me/certifications.json'.format(BASE_URL)
+ME_URL = '{}/me'.format(BASE_URL)
+ME_REQUEST_URL = '{}/me/submission_requests.json'.format(BASE_URL)
+CREATE_REQUEST_URL = '{}/submission_requests.json'.format(BASE_URL)
+DELETE_URL_TMPL = '{}/submission_requests/{}.json'
+GET_REQUEST_URL_TMPL = '{}/submission_requests/{}.json'
+PUT_REQUEST_URL_TMPL = '{}/submission_requests/{}.json'
+REFRESH_URL_TMPL = '{}/submission_requests/{}/refresh.json'
+ASSIGNED_COUNT_URL = '{}/me/submissions/assigned_count.json'.format(BASE_URL)
+ASSIGNED_URL = '{}/me/submissions/assigned.json'.format(BASE_URL)
+
+# Assign token
+os.environ["UDACITY_AUTH_TOKEN"] = config.user_token
+
+REVIEW_URL = 'https://review.udacity.com/#!/submissions/{sid}'
+REQUESTS_PER_SECOND = 1 # Please leave this alone.
+
+logging.basicConfig(format='|%(asctime)s| %(message)s')
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+headers = None
+
+def signal_handler(signal, frame):
+    if headers:
+        logger.info('Cleaning up active request')
+        me_resp = requests.get(ME_REQUEST_URL, headers=headers)
+        if me_resp.status_code == 200 and len(me_resp.json()) > 0:
+            logger.info(DELETE_URL_TMPL.format(BASE_URL, me_resp.json()[0]['id']))
+            del_resp = requests.delete(DELETE_URL_TMPL.format(BASE_URL, me_resp.json()[0]['id']),
+                                       headers=headers)
+            logger.info(del_resp)
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, signal_handler)
+
+def alert_for_assignment(current_request, headers):
+    if current_request and current_request['status'] == 'fulfilled':
+        logger.info("")
+        logger.info("=================================================")
+        logger.info("You have been assigned to grade a new submission!")
+        logger.info("View it here: " + REVIEW_URL.format(sid=current_request['submission_id']))
+        logger.info("=================================================")
+        logger.info("Continuing to poll...")
+        return None
+    return current_request
+
+def wait_for_assign_eligible():
+    while True:
+        assigned_resp = requests.get(ASSIGNED_COUNT_URL, headers=headers)
+        if assigned_resp.status_code == 404 or assigned_resp.json()['assigned_count'] < 2:
+            break
+        else:
+            logger.info('Waiting for assigned submissions < 2')
+        # Wait 30 seconds before checking to see if < 2 open submissions
+        # that is, waiting until a create submission request will be permitted
+        time.sleep(30.0)
+
+def refresh_request(current_request):
+    logger.info('Refreshing existing request')
+    refresh_resp = requests.put(REFRESH_URL_TMPL.format(BASE_URL, current_request['id']),
+                                headers=headers)
+    refresh_resp.raise_for_status()
+    if refresh_resp.status_code == 404:
+        logger.info('No active request was found/refreshed.  Loop and either wait for < 2 to be assigned or immediately create')
+        return None
+    else:
+        return refresh_resp.json()
+
+def fetch_certified_pairs(ids_queued=None):
+    logger.info("Requesting certifications...")
+    me_resp = requests.get(ME_URL, headers=headers)
+    me_resp.raise_for_status()
+    languages = me_resp.json()['application']['languages'] or ['en-us']
+
+    certs_resp = requests.get(CERTS_URL, headers=headers)
+    certs_resp.raise_for_status()
+
+    certs = certs_resp.json()
+    
+    project_ids = [cert['project']['id'] for cert in certs if cert['status'] == 'certified']
+
+    logger.info("Found certifications for project IDs: %s in languages %s",
+                str(project_ids), str(languages))
+    logger.info("Polling for new submissions...")
+    
+    projects_to_query(certs,ids_queued)
+    
+    proj_queued = [{'project_id': project_id, 'language': lang} for project_id in project_ids  for lang in languages]
+    
+    if ids_queued is not None:
+        return [x for x in proj_queued if x['project_id'] in ids_queued]
+    else:
+        return proj_queued
+
+def projects_to_query(certifications,ids_queued=None):
+    # project characteristics to retrieve:
+    project_description = [u'status',u'id',u'price',u'name',u'hashtag']
+    
+    # retrieve project information:
+    proj_info = {}
+    
+    for i,certi in enumerate(certifications):
+        proj_info[i] = {}
+        for field in certi.keys():
+            if field in project_description: 
+                if field != 'id': proj_info[i][field] = certi[field]
+            if field == 'project':
+                for field_proj in certi[field].keys():
+                    if field_proj in project_description: proj_info[i][field_proj] = certi[field][field_proj]
+
+    # Print in terminal all available projects:
+    print "\n\nAll available projects:\n"
+    print "{p[3]:^50} | {p[1]:^5} | {p[2]:^5} | {p[0]:^15} | {p[4]:^50}".format(p=project_description)
+    for proj in  proj_info.keys():
+        print "{p[name]:50} | {p[id]:^5} | {p[price]:^5} | {p[status]:^15} | {p[hashtag]:50}".format(p=proj_info[proj])
+        
+    # Select just those projects selected by ids:
+    if ids_queued is not None:
+        print "\n\nSelected projects to queue:\n"
+        print "{p[3]:^50} | {p[1]:^5} | {p[2]:^5} | {p[0]:^15} | {p[4]:^50}".format(p=project_description)
+        for proj in  proj_info.keys():
+            if proj_info[proj][u'id'] in ids_queued:
+                print "{p[name]:50} | {p[id]:^5} | {p[price]:^5} | {p[status]:^15} | {p[hashtag]:50}".format(p=proj_info[proj])
+    else:
+        print "\n All projects requested!\n"
+    
+
+def request_reviews(token,ids_queued=None):
+    global headers
+    headers = {'Authorization': token, 'Content-Length': '0'}
+
+    project_language_pairs = fetch_certified_pairs(ids_queued=None)
+    logger.info("Will poll for projects/languages %s", str(project_language_pairs))
+    
+    me_req_resp = requests.get(ME_REQUEST_URL, headers=headers)
+    current_request = me_req_resp.json()[0] if me_req_resp.status_code == 201 and len(me_req_resp.json()) > 0 else None
+    
+
+    if current_request:
+        update_resp = requests.put(PUT_REQUEST_URL_TMPL.format(BASE_URL, current_request['id']),
+                                   json={'projects': project_language_pairs}, headers=headers)
+        current_request = update_resp.json() if update_resp.status_code == 200 else current_request
+
+    while True:
+        # Loop and wait until fewer than 2 reviews assigned, as creating
+        # a request will fail
+        wait_for_assign_eligible()
+
+        if current_request is None:
+            logger.info('Creating a request for ' + str(len(project_language_pairs)) +
+                        ' possible project/language combinations')
+            create_resp = requests.post(CREATE_REQUEST_URL,
+                                        json={'projects': project_language_pairs},
+                                        headers=headers)
+            current_request = create_resp.json() if create_resp.status_code == 201 else None
+        else:
+            logger.info(current_request)
+            closing_at = parser.parse(current_request['closed_at'])
+
+            utcnow = datetime.utcnow()
+            utcnow = utcnow.replace(tzinfo=pytz.utc)
+
+            if closing_at < utcnow + timedelta(minutes=59):
+                # Refreshing a request is more costly than just loading
+                # and only needs to be done to ensure the request doesn't
+                # expire (1 hour)
+                logger.info('0-0-0-0-0-0-0-0-0-0- refreshing request 0-0-0-0-0-0-0')
+                current_request = refresh_request(current_request)
+            else:
+                logger.info('Checking for new assignments')
+                # If an assignment has been made since status was last checked,
+                # the request record will no longer be 'fulfilled'
+                url = GET_REQUEST_URL_TMPL.format(BASE_URL, current_request['id'])
+                get_req_resp = requests.get(url, headers=headers)
+                current_request = get_req_resp.json() if me_req_resp.status_code == 200 else None
+
+        current_request = alert_for_assignment(current_request, headers)
+        if current_request:
+            # Wait 2 minutes before next check to see if the request has been fulfilled
+            time.sleep(120.0)
+    
+if __name__ == "__main__":
+    cmd_parser = argparse.ArgumentParser(description =
+    "Poll the Udacity reviews API to claim projects to review."
+    )
+    cmd_parser.add_argument('--auth-token', '-T', dest='token',
+    metavar='TOKEN', type=str,
+    action='store', default=os.environ.get('UDACITY_AUTH_TOKEN'),
+    help="""
+        Your Udacity auth token. To obtain, login to review.udacity.com, open the Javascript console, and copy the output of `JSON.parse(localStorage.currentUser).token`.  This can also be stored in the environment variable UDACITY_AUTH_TOKEN.
+    """
+    )
+    cmd_parser.add_argument('--debug', '-d', action='store_true', help='Turn on debug statements.')
+    cmd_parser.add_argument('--ids', '-ids', help='Select particular projects ids to queue.', dest='ids_queued', default=config.ids_queued)
+    args = cmd_parser.parse_args()
+
+    if not args.token:
+        cmd_parser.print_help()
+        cmd_parser.exit()
+
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+        
+    request_reviews(args.token, args.ids_queued)


### PR DESCRIPTION
`fetch_certified_pairs` function is modified, `projects_to_query` function is created to allow users to queue only those projects ids desired. A `config.py` file is used to define user token and a list
with the particular projects ids to query.

 Changes to be committed:
	new file:   config.py
	new file:   grading_assigment.py