### PR TITLE
fix: Use correct json key for languages

### DIFF
--- a/grading-assigner.py
+++ b/grading-assigner.py
@@ -84,7 +84,7 @@ def fetch_certified_pairs():
     logger.info("Requesting certifications...")
     me_resp = requests.get(ME_URL, headers=headers)
     me_resp.raise_for_status()
-    languages = me_resp.json()['application']['languages'] or ['en-us']
+    languages = me_resp.json()['mentor_languages'] or ['en-us']
 
     certs_resp = requests.get(CERTS_URL, headers=headers)
     certs_resp.raise_for_status()


### PR DESCRIPTION
The Udacity response seems to have changed recently. Updating
the code to read languages from the newer JSON field